### PR TITLE
Update LabelCollection.php

### DIFF
--- a/src/Collections/LabelCollection.php
+++ b/src/Collections/LabelCollection.php
@@ -62,7 +62,7 @@ final class LabelCollection implements Countable, IteratorAggregate
 		}
 	}
 
-	public function getIterator() : iterable
+	public function getIterator() : \Traversable
 	{
 		yield from $this->labels;
 	}


### PR DESCRIPTION
Deprecated: Return type of OpenMetricsPhp\Exposition\Text\Collections\LabelCollection::getIterator(): Traversable |array should either be compatible with IteratorAggregate::getIterator(): Traversable

Fixes #`8`

## Proposed Changes

make the getIterator() Traversable instead of Iterable

## Further comments
