### PR TITLE
Remove space between labels

### DIFF
--- a/src/Collections/LabelCollection.php
+++ b/src/Collections/LabelCollection.php
@@ -87,6 +87,6 @@ final class LabelCollection implements CollectsLabels
 			$this->labels
 		);
 
-		return '{' . implode( ', ', $labelStrings ) . '}';
+		return '{' . implode( ',', $labelStrings ) . '}';
 	}
 }

--- a/tests/Integration/OpenMetrics/PythonParserTest.php
+++ b/tests/Integration/OpenMetrics/PythonParserTest.php
@@ -78,7 +78,7 @@ final class PythonParserTest extends TestCase
 	public function testCanParseGaugeMetricsWithPythonParser() : void
 	{
 		$expectedParserOutput = "Name: gauge Labels: {'foo': 'bar'} Value: 1.01 Timestamp: 1234567.000000000\n"
-		                        . "Name: gauge Labels: {'bar': 'foo'} Value: 2.0202 Timestamp: 1234567.000000000\n"
+		                        . "Name: gauge Labels: {'foobar': 'foo', 'bar': 'foo'} Value: 2.0202 Timestamp: 1234567.000000000\n"
 		                        . "Name: gauge Labels: {} Value: 3.0302 Timestamp: None\n";
 
 		$collection = GaugeCollection::fromGauges(
@@ -86,9 +86,9 @@ final class PythonParserTest extends TestCase
 			Gauge::fromValueAndTimestamp( 1.01, 1234567 )->withLabels(
 				Label::fromNameAndValue( 'foo', 'bar' )
 			),
-			Gauge::fromValueAndTimestamp( 2.0202, 1234567 )->withLabels(
-				Label::fromNameAndValue( 'bar', 'foo' )
-			),
+			Gauge::fromValueAndTimestamp( 2.0202, 1234567 )
+            ->withLabels(Label::fromNameAndValue( 'foobar', 'foo' ))
+            ->withLabels(Label::fromNameAndValue( 'bar', 'foo' ) ),
 			Gauge::fromValue( 3.0302 )
 		);
 

--- a/tests/Unit/Collections/LabelCollectionTest.php
+++ b/tests/Unit/Collections/LabelCollectionTest.php
@@ -86,7 +86,7 @@ final class LabelCollectionTest extends TestCase
 		/** @var ProvidesNamedValue $secondLabelStub */
 		$collection->add( $secondLabelStub );
 
-		$this->assertSame( '{name1="value1", name2="value2"}', $collection->getCombinedLabelString() );
+		$this->assertSame( '{name1="value1",name2="value2"}', $collection->getCombinedLabelString() );
 	}
 
 	/**
@@ -139,7 +139,7 @@ final class LabelCollectionTest extends TestCase
 		$collection->add( $firstLabelStub, $secondLabelStub );
 
 		$this->assertCount( 2, $collection );
-		$this->assertSame( '{name1="value1", name2="value2"}', $collection->getCombinedLabelString() );
+		$this->assertSame( '{name1="value1",name2="value2"}', $collection->getCombinedLabelString() );
 	}
 
 	/**
@@ -158,7 +158,7 @@ final class LabelCollectionTest extends TestCase
 
 		$this->assertCount( 2, $labels );
 
-		$expectedLabelString = '{unit="test", test="unit"}';
+		$expectedLabelString = '{unit="test",test="unit"}';
 
 		$this->assertSame( $expectedLabelString, $labels->getCombinedLabelString() );
 	}

--- a/tests/Unit/Metrics/CounterTest.php
+++ b/tests/Unit/Metrics/CounterTest.php
@@ -68,7 +68,7 @@ final class CounterTest extends TestCase
 	{
 		$expectedSampleStringWithoutLabels   = '_total 1.000000';
 		$expectedSampleStringWithOneLabel    = '_total{unit_test="123"} 1.000000';
-		$expectedSampleStringWithThreeLabels = '_total{unit_test="123", test_unit="456", label_last="789"} 1.000000';
+		$expectedSampleStringWithThreeLabels = '_total{unit_test="123",test_unit="456",label_last="789"} 1.000000';
 
 		$gauge = Counter::fromValue( 1 );
 
@@ -99,7 +99,7 @@ final class CounterTest extends TestCase
 			                Label::fromNameAndValue( 'test', 'unit' )
 		                );
 
-		$expectedSampleString = '_total{unit="test", test="unit"} 12.300000';
+		$expectedSampleString = '_total{unit="test",test="unit"} 12.300000';
 
 		$this->assertSame( $expectedSampleString, $gauge->getSampleString() );
 	}
@@ -121,7 +121,7 @@ final class CounterTest extends TestCase
 			                )
 		                );
 
-		$expectedSampleString = '_total{unit="test", test="unit"} 12.300000';
+		$expectedSampleString = '_total{unit="test",test="unit"} 12.300000';
 
 		$this->assertSame( $expectedSampleString, $gauge->getSampleString() );
 	}

--- a/tests/Unit/Metrics/GaugeTest.php
+++ b/tests/Unit/Metrics/GaugeTest.php
@@ -65,7 +65,7 @@ final class GaugeTest extends TestCase
 	{
 		$expectedSampleStringWithoutLabels   = ' 1.230000';
 		$expectedSampleStringWithOneLabel    = '{unit_test="123"} 1.230000';
-		$expectedSampleStringWithThreeLabels = '{unit_test="123", test_unit="456", label_last="789"} 1.230000';
+		$expectedSampleStringWithThreeLabels = '{unit_test="123",test_unit="456",label_last="789"} 1.230000';
 
 		$gauge = Gauge::fromValue( 1.23 );
 
@@ -97,7 +97,7 @@ final class GaugeTest extends TestCase
 			Label::fromNameAndValue( 'test', 'unit' )
 		);
 
-		$expectedSampleString = '{unit="test", test="unit"} 12.300000';
+		$expectedSampleString = '{unit="test",test="unit"} 12.300000';
 
 		$this->assertSame( $expectedSampleString, $gauge->getSampleString() );
 	}
@@ -120,7 +120,7 @@ final class GaugeTest extends TestCase
 			)
 		);
 
-		$expectedSampleString = '{unit="test", test="unit"} 12.300000';
+		$expectedSampleString = '{unit="test",test="unit"} 12.300000';
 
 		$this->assertSame( $expectedSampleString, $gauge->getSampleString() );
 	}


### PR DESCRIPTION
According to spec labels are separated by a comma, without any whitespace. To show this behavior we changed the integration test to have one case with 2 labels. This makes the integrationtest fail.

We are using the `withLabels` method twice because their is an incompatibility between php 7.3 and 7.4 vardict arguments are different ordered between those versions. By calling the method twice we can make sure the order is kept.